### PR TITLE
Remove enabled parameter from toolinfo initialization

### DIFF
--- a/src/moodle_mcp_server/middleware.py
+++ b/src/moodle_mcp_server/middleware.py
@@ -156,7 +156,6 @@ class MoodleMiddleware(Middleware):
             parameters=toolinfo.get("inputSchema"),
             output_schema=toolinfo.get("outputSchema"),
             icons=[self.icon],
-            enabled=True,
         )
 
 


### PR DESCRIPTION
This patch was needed in order to run the MCP together with MCP Inspector and MCPO who were returning both similar error:

mcpo | [05/08/26 07:42:51] INFO Starting MCP server 'Moodle MCP transport.py:209
mcpo | Server' with transport 'stdio'
mcpo | 2026-05-08 07:42:58,102 - ERROR - Failed to connect to MCP server 'Moodle MCP Server': McpError: 1 validation error for Tool
mcpo | enabled
mcpo | Extra inputs are not permitted [type=extra_forbidden, input_value=True, input_type=bool]
mcpo | For further information visit https://errors.pydantic.dev/2.13/v/extra_forbidden
mcpo | Traceback (most recent call last):
mcpo | File "/app/.venv/lib/python3.12/site-packages/mcpo/main.py", line 719, in lifespan
mcpo | await create_dynamic_endpoints(app, api_dependency=api_dependency)
mcpo | File "/app/.venv/lib/python3.12/site-packages/mcpo/main.py", line 518, in create_dynamic_endpoints
mcpo | tools_result = await session.list_tools()
mcpo | ^^^^^^^^^^^^^^^^^^^^^^^^^^
mcpo | File "/app/.venv/lib/python3.12/site-packages/mcp/client/session.py", line 529, in list_tools
mcpo | result = await self.send_request(
mcpo | ^^^^^^^^^^^^^^^^^^^^^^^^
mcpo | File "/app/.venv/lib/python3.12/site-packages/mcp/shared/session.py", line 306, in send_request
mcpo | raise McpError(response_or_error.error)
mcpo | mcp.shared.exceptions.McpError: 1 validation error for Tool
mcpo | enabled